### PR TITLE
README・ライセンス追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tomii9273
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [麻雀大会卓組表](https://tomii6614.web.fc2.com/) に掲載している卓組の作成に使用したソースコードを公開しています。
 
+## ライセンス
+
+MIT License
+
 ## 関連リンク
 
 - 作成者 X (Twitter): https://twitter.com/Tomii9273

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# takugumi_code
+
+[麻雀大会卓組表](https://tomii6614.web.fc2.com/) に掲載している卓組の作成に使用したソースコードを公開しています。
+
+## 関連リンク
+
+- 作成者 X (Twitter): https://twitter.com/Tomii9273
+- 麻雀大会卓組表 GitHub リポジトリ: https://github.com/tomii9273/mahjong_takugumi


### PR DESCRIPTION
このリポジトリは、[麻雀大会卓組表](https://tomii6614.web.fc2.com/)に掲載している卓組のソースコードをあげるものとして作成していたが、サイトとともに数年間更新していなかった。
2023年10月頃からサイトの更新を再開し、各種卓組の作成方法ページができてきたので、ソースコードのアップロードも再開していきたい。
そのための準備をした。